### PR TITLE
0.2.0

### DIFF
--- a/Playwright.BrowserDownloader/Constants.cs
+++ b/Playwright.BrowserDownloader/Constants.cs
@@ -1,263 +1,396 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace nor0x.Playwright.BrowserDownloader;
 public static class Constants
 {
-    public static string HostedBrowsersJson = "https://raw.githubusercontent.com/nor0x/Playwright.BrowserDownloader/main/Playwright.BrowserDownloader/browsers.json";
+	public static string HostedBrowsersJson = "https://raw.githubusercontent.com/nor0x/Playwright.BrowserDownloader/main/Playwright.BrowserDownloader/browsers.json";
 
-    //from playwright/lib/server/registry/index.js
-    public static Dictionary<string, Dictionary<string, string>> Paths = new() {
-    {
-      "chromium",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/chromium/{0}/chromium-linux.zip",
-        ["ubuntu22.04-x64"] = "builds/chromium/{0}/chromium-linux.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
-        ["ubuntu22.04-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
-        ["debian11-x64"] = "builds/chromium/{0}/chromium-linux.zip",
-        ["debian11-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
-        ["debian12-x64"] = "builds/chromium/{0}/chromium-linux.zip",
-        ["debian12-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
-        ["mac10.13"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac10.14"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac10.15"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac11"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac11-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
-        ["mac12"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac12-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
-        ["mac13"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac13-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
-        ["mac14"] = "builds/chromium/{0}/chromium-mac.zip",
-        ["mac14-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
-        ["win64"] = "builds/chromium/{0}/chromium-win64.zip",
-      }
-    }, {
-      "chromium-tip-of-tree",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
-        ["ubuntu22.04-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
-        ["ubuntu22.04-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
-        ["debian11-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
-        ["debian11-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
-        ["debian12-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
-        ["debian12-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
-        ["mac10.13"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac10.14"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac10.15"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac11"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac11-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
-        ["mac12"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac12-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
-        ["mac13"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac13-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
-        ["mac14"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
-        ["mac14-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
-        ["win64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-win64.zip",
-      }
-    }, {
-      "firefox",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/firefox/{0}/firefox-ubuntu-20.04.zip",
-        ["ubuntu22.04-x64"] = "builds/firefox/{0}/firefox-ubuntu-22.04.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = "builds/firefox/{0}/firefox-ubuntu-20.04-arm64.zip",
-        ["ubuntu22.04-arm64"] = "builds/firefox/{0}/firefox-ubuntu-22.04-arm64.zip",
-        ["debian11-x64"] = "builds/firefox/{0}/firefox-debian-11.zip",
-        ["debian11-arm64"] = "builds/firefox/{0}/firefox-debian-11-arm64.zip",
-        ["debian12-x64"] = "builds/firefox/{0}/firefox-debian-12.zip",
-        ["debian12-arm64"] = "builds/firefox/{0}/firefox-debian-12-arm64.zip",
-        ["mac10.13"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac10.14"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac10.15"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac11"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac11-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
-        ["mac12"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac12-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
-        ["mac13"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac13-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
-        ["mac14"] = "builds/firefox/{0}/firefox-mac-13.zip",
-        ["mac14-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
-        ["win64"] = "builds/firefox/{0}/firefox-win64.zip",
-      }
-    }, {
-      "firefox-beta",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/firefox-beta/{0}/firefox-beta-ubuntu-20.04.zip",
-        ["ubuntu22.04-x64"] = "builds/firefox-beta/{0}/firefox-beta-ubuntu-22.04.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = null,
-        ["ubuntu22.04-arm64"] = "builds/firefox-beta/{0}/firefox-beta-ubuntu-22.04-arm64.zip",
-        ["debian11-x64"] = "builds/firefox-beta/{0}/firefox-beta-debian-11.zip",
-        ["debian11-arm64"] = "builds/firefox-beta/{0}/firefox-beta-debian-11-arm64.zip",
-        ["debian12-x64"] = "builds/firefox-beta/{0}/firefox-beta-debian-12.zip",
-        ["debian12-arm64"] = "builds/firefox-beta/{0}/firefox-beta-debian-12-arm64.zip",
-        ["mac10.13"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac10.14"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac10.15"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac11"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac11-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
-        ["mac12"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac12-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
-        ["mac13"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac13-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
-        ["mac14"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
-        ["mac14-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
-        ["win64"] = "builds/firefox-beta/{0}/firefox-beta-win64.zip",
-      }
-    }, {
-      "firefox-asan",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = null,
-        ["ubuntu22.04-x64"] = "builds/firefox/{0}/firefox-asan-ubuntu-22.04.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = null,
-        ["ubuntu22.04-arm64"] = null,
-        ["debian11-x64"] = null,
-        ["debian11-arm64"] = null,
-        ["debian12-x64"] = null,
-        ["debian12-arm64"] = null,
-        ["mac10.13"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac10.14"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac10.15"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac11"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac11-arm64"] = null,
-        ["mac12"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac12-arm64"] = null,
-        ["mac13"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac13-arm64"] = null,
-        ["mac14"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-        ["mac14-arm64"] = null,
-        ["win64"] = null,
-      }
-    }, {
-      "webkit",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/webkit/{0}/webkit-ubuntu-20.04.zip",
-        ["ubuntu22.04-x64"] = "builds/webkit/{0}/webkit-ubuntu-22.04.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = "builds/webkit/{0}/webkit-ubuntu-20.04-arm64.zip",
-        ["ubuntu22.04-arm64"] = "builds/webkit/{0}/webkit-ubuntu-22.04-arm64.zip",
-        ["debian11-x64"] = "builds/webkit/{0}/webkit-debian-11.zip",
-        ["debian11-arm64"] = "builds/webkit/{0}/webkit-debian-11-arm64.zip",
-        ["debian12-x64"] = "builds/webkit/{0}/webkit-debian-12.zip",
-        ["debian12-arm64"] = "builds/webkit/{0}/webkit-debian-12-arm64.zip",
-        ["mac10.13"] = null,
-        ["mac10.14"] = "builds/deprecated-webkit-mac-10.14/{0}/deprecated-webkit-mac-10.14.zip",
-        ["mac10.15"] = "builds/deprecated-webkit-mac-10.15/{0}/deprecated-webkit-mac-10.15.zip",
-        ["mac11"] = "builds/webkit/{0}/webkit-mac-11.zip",
-        ["mac11-arm64"] = "builds/webkit/{0}/webkit-mac-11-arm64.zip",
-        ["mac12"] = "builds/webkit/{0}/webkit-mac-12.zip",
-        ["mac12-arm64"] = "builds/webkit/{0}/webkit-mac-12-arm64.zip",
-        ["mac13"] = "builds/webkit/{0}/webkit-mac-13.zip",
-        ["mac13-arm64"] = "builds/webkit/{0}/webkit-mac-13-arm64.zip",
-        ["mac14"] = "builds/webkit/{0}/webkit-mac-14.zip",
-        ["mac14-arm64"] = "builds/webkit/{0}/webkit-mac-14-arm64.zip",
-        ["win64"] = "builds/webkit/{0}/webkit-win64.zip",
-      }
-    }, {
-      "ffmpeg",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = null,
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
-        ["ubuntu22.04-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
-        ["ubuntu22.04-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
-        ["debian11-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
-        ["debian11-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
-        ["debian12-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
-        ["debian12-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
-        ["mac10.13"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac10.14"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac10.15"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac11"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac11-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
-        ["mac12"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac12-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
-        ["mac13"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac13-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
-        ["mac14"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
-        ["mac14-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
-        ["win64"] = "builds/ffmpeg/{0}/ffmpeg-win64.zip",
-      }
-    }, {
-      "android",
-      new Dictionary < string,
-      string > {
-        ["<unknown>"] = "builds/android/{0}/android.zip",
-        ["ubuntu18.04-x64"] = null,
-        ["ubuntu20.04-x64"] = "builds/android/{0}/android.zip",
-        ["ubuntu22.04-x64"] = "builds/android/{0}/android.zip",
-        ["ubuntu18.04-arm64"] = null,
-        ["ubuntu20.04-arm64"] = "builds/android/{0}/android.zip",
-        ["ubuntu22.04-arm64"] = "builds/android/{0}/android.zip",
-        ["debian11-x64"] = "builds/android/{0}/android.zip",
-        ["debian11-arm64"] = "builds/android/{0}/android.zip",
-        ["debian12-x64"] = "builds/android/{0}/android.zip",
-        ["debian12-arm64"] = "builds/android/{0}/android.zip",
-        ["mac10.13"] = "builds/android/{0}/android.zip",
-        ["mac10.14"] = "builds/android/{0}/android.zip",
-        ["mac10.15"] = "builds/android/{0}/android.zip",
-        ["mac11"] = "builds/android/{0}/android.zip",
-        ["mac11-arm64"] = "builds/android/{0}/android.zip",
-        ["mac12"] = "builds/android/{0}/android.zip",
-        ["mac12-arm64"] = "builds/android/{0}/android.zip",
-        ["mac13"] = "builds/android/{0}/android.zip",
-        ["mac13-arm64"] = "builds/android/{0}/android.zip",
-        ["mac14"] = "builds/android/{0}/android.zip",
-        ["mac14-arm64"] = "builds/android/{0}/android.zip",
-        ["win64"] = "builds/android/{0}/android.zip",
-      }
-    }
+	public static Dictionary<string, Dictionary<string, string>> ExecutablePaths = new Dictionary<string, Dictionary<string, string>>
+		{
+			{
+				"chromium", new Dictionary<string, string>
+				{
+					{ "linux", "chrome-linux, chrome" },
+					{ "mac", "chrome-mac, Chromium.app, Contents, MacOS, Chromium" },
+					{ "win", "chrome-win, chrome.exe" }
+				}
+			},
+			{
+				"firefox", new Dictionary<string, string>
+				{
+					{ "linux", "firefox, firefox" },
+					{ "mac", "firefox, Nightly.app, Contents, MacOS, firefox" },
+					{ "win", "firefox, firefox.exe" }
+				}
+			},
+			{
+				"webkit", new Dictionary<string, string>
+				{
+					{ "linux", "pw_run.sh" },
+					{ "mac", "pw_run.sh" },
+					{ "win", "Playwright.exe" }
+				}
+			},
+			{
+				"ffmpeg", new Dictionary<string, string>
+				{
+					{ "linux", "ffmpeg-linux" },
+					{ "mac", "ffmpeg-mac" },
+					{ "win", "ffmpeg-win64.exe" }
+				}
+			}
+		};
+
+	//from https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/index.ts
+	public static Dictionary<string, Dictionary<string, string>> Paths = new() {
+	{
+	  "chromium",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/chromium/{0}/chromium-linux.zip",
+		["ubuntu22.04-x64"] = "builds/chromium/{0}/chromium-linux.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
+		["ubuntu22.04-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
+		["debian11-x64"] = "builds/chromium/{0}/chromium-linux.zip",
+		["debian11-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
+		["debian12-x64"] = "builds/chromium/{0}/chromium-linux.zip",
+		["debian12-arm64"] = "builds/chromium/{0}/chromium-linux-arm64.zip",
+		["mac10.13"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac10.14"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac10.15"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac11"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac11-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
+		["mac12"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac12-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
+		["mac13"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac13-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
+		["mac14"] = "builds/chromium/{0}/chromium-mac.zip",
+		["mac14-arm64"] = "builds/chromium/{0}/chromium-mac-arm64.zip",
+		["win64"] = "builds/chromium/{0}/chromium-win64.zip",
+	  }
+	}, {
+	  "chromium-tip-of-tree",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
+		["ubuntu22.04-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
+		["ubuntu22.04-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
+		["debian11-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
+		["debian11-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
+		["debian12-x64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux.zip",
+		["debian12-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-linux-arm64.zip",
+		["mac10.13"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac10.14"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac10.15"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac11"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac11-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
+		["mac12"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac12-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
+		["mac13"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac13-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
+		["mac14"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac.zip",
+		["mac14-arm64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-mac-arm64.zip",
+		["win64"] = "builds/chromium-tip-of-tree/{0}/chromium-tip-of-tree-win64.zip",
+	  }
+	}, {
+	  "firefox",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/firefox/{0}/firefox-ubuntu-20.04.zip",
+		["ubuntu22.04-x64"] = "builds/firefox/{0}/firefox-ubuntu-22.04.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = "builds/firefox/{0}/firefox-ubuntu-20.04-arm64.zip",
+		["ubuntu22.04-arm64"] = "builds/firefox/{0}/firefox-ubuntu-22.04-arm64.zip",
+		["debian11-x64"] = "builds/firefox/{0}/firefox-debian-11.zip",
+		["debian11-arm64"] = "builds/firefox/{0}/firefox-debian-11-arm64.zip",
+		["debian12-x64"] = "builds/firefox/{0}/firefox-debian-12.zip",
+		["debian12-arm64"] = "builds/firefox/{0}/firefox-debian-12-arm64.zip",
+		["mac10.13"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac10.14"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac10.15"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac11"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac11-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
+		["mac12"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac12-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
+		["mac13"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac13-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
+		["mac14"] = "builds/firefox/{0}/firefox-mac-13.zip",
+		["mac14-arm64"] = "builds/firefox/{0}/firefox-mac-13-arm64.zip",
+		["win64"] = "builds/firefox/{0}/firefox-win64.zip",
+	  }
+	}, {
+	  "firefox-beta",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/firefox-beta/{0}/firefox-beta-ubuntu-20.04.zip",
+		["ubuntu22.04-x64"] = "builds/firefox-beta/{0}/firefox-beta-ubuntu-22.04.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = null,
+		["ubuntu22.04-arm64"] = "builds/firefox-beta/{0}/firefox-beta-ubuntu-22.04-arm64.zip",
+		["debian11-x64"] = "builds/firefox-beta/{0}/firefox-beta-debian-11.zip",
+		["debian11-arm64"] = "builds/firefox-beta/{0}/firefox-beta-debian-11-arm64.zip",
+		["debian12-x64"] = "builds/firefox-beta/{0}/firefox-beta-debian-12.zip",
+		["debian12-arm64"] = "builds/firefox-beta/{0}/firefox-beta-debian-12-arm64.zip",
+		["mac10.13"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac10.14"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac10.15"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac11"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac11-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
+		["mac12"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac12-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
+		["mac13"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac13-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
+		["mac14"] = "builds/firefox-beta/{0}/firefox-beta-mac-13.zip",
+		["mac14-arm64"] = "builds/firefox-beta/{0}/firefox-beta-mac-13-arm64.zip",
+		["win64"] = "builds/firefox-beta/{0}/firefox-beta-win64.zip",
+	  }
+	}, {
+	  "firefox-asan",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = null,
+		["ubuntu22.04-x64"] = "builds/firefox/{0}/firefox-asan-ubuntu-22.04.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = null,
+		["ubuntu22.04-arm64"] = null,
+		["debian11-x64"] = null,
+		["debian11-arm64"] = null,
+		["debian12-x64"] = null,
+		["debian12-arm64"] = null,
+		["mac10.13"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac10.14"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac10.15"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac11"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac11-arm64"] = null,
+		["mac12"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac12-arm64"] = null,
+		["mac13"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac13-arm64"] = null,
+		["mac14"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
+		["mac14-arm64"] = null,
+		["win64"] = null,
+	  }
+	}, {
+	  "webkit",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/webkit/{0}/webkit-ubuntu-20.04.zip",
+		["ubuntu22.04-x64"] = "builds/webkit/{0}/webkit-ubuntu-22.04.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = "builds/webkit/{0}/webkit-ubuntu-20.04-arm64.zip",
+		["ubuntu22.04-arm64"] = "builds/webkit/{0}/webkit-ubuntu-22.04-arm64.zip",
+		["debian11-x64"] = "builds/webkit/{0}/webkit-debian-11.zip",
+		["debian11-arm64"] = "builds/webkit/{0}/webkit-debian-11-arm64.zip",
+		["debian12-x64"] = "builds/webkit/{0}/webkit-debian-12.zip",
+		["debian12-arm64"] = "builds/webkit/{0}/webkit-debian-12-arm64.zip",
+		["mac10.13"] = null,
+		["mac10.14"] = "builds/deprecated-webkit-mac-10.14/{0}/deprecated-webkit-mac-10.14.zip",
+		["mac10.15"] = "builds/deprecated-webkit-mac-10.15/{0}/deprecated-webkit-mac-10.15.zip",
+		["mac11"] = "builds/webkit/{0}/webkit-mac-11.zip",
+		["mac11-arm64"] = "builds/webkit/{0}/webkit-mac-11-arm64.zip",
+		["mac12"] = "builds/webkit/{0}/webkit-mac-12.zip",
+		["mac12-arm64"] = "builds/webkit/{0}/webkit-mac-12-arm64.zip",
+		["mac13"] = "builds/webkit/{0}/webkit-mac-13.zip",
+		["mac13-arm64"] = "builds/webkit/{0}/webkit-mac-13-arm64.zip",
+		["mac14"] = "builds/webkit/{0}/webkit-mac-14.zip",
+		["mac14-arm64"] = "builds/webkit/{0}/webkit-mac-14-arm64.zip",
+		["win64"] = "builds/webkit/{0}/webkit-win64.zip",
+	  }
+	}, {
+	  "ffmpeg",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = null,
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
+		["ubuntu22.04-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
+		["ubuntu22.04-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
+		["debian11-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
+		["debian11-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
+		["debian12-x64"] = "builds/ffmpeg/{0}/ffmpeg-linux.zip",
+		["debian12-arm64"] = "builds/ffmpeg/{0}/ffmpeg-linux-arm64.zip",
+		["mac10.13"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac10.14"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac10.15"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac11"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac11-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
+		["mac12"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac12-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
+		["mac13"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac13-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
+		["mac14"] = "builds/ffmpeg/{0}/ffmpeg-mac.zip",
+		["mac14-arm64"] = "builds/ffmpeg/{0}/ffmpeg-mac-arm64.zip",
+		["win64"] = "builds/ffmpeg/{0}/ffmpeg-win64.zip",
+	  }
+	}, {
+	  "android",
+	  new Dictionary < string,
+	  string > {
+		["<unknown>"] = "builds/android/{0}/android.zip",
+		["ubuntu18.04-x64"] = null,
+		["ubuntu20.04-x64"] = "builds/android/{0}/android.zip",
+		["ubuntu22.04-x64"] = "builds/android/{0}/android.zip",
+		["ubuntu18.04-arm64"] = null,
+		["ubuntu20.04-arm64"] = "builds/android/{0}/android.zip",
+		["ubuntu22.04-arm64"] = "builds/android/{0}/android.zip",
+		["debian11-x64"] = "builds/android/{0}/android.zip",
+		["debian11-arm64"] = "builds/android/{0}/android.zip",
+		["debian12-x64"] = "builds/android/{0}/android.zip",
+		["debian12-arm64"] = "builds/android/{0}/android.zip",
+		["mac10.13"] = "builds/android/{0}/android.zip",
+		["mac10.14"] = "builds/android/{0}/android.zip",
+		["mac10.15"] = "builds/android/{0}/android.zip",
+		["mac11"] = "builds/android/{0}/android.zip",
+		["mac11-arm64"] = "builds/android/{0}/android.zip",
+		["mac12"] = "builds/android/{0}/android.zip",
+		["mac12-arm64"] = "builds/android/{0}/android.zip",
+		["mac13"] = "builds/android/{0}/android.zip",
+		["mac13-arm64"] = "builds/android/{0}/android.zip",
+		["mac14"] = "builds/android/{0}/android.zip",
+		["mac14-arm64"] = "builds/android/{0}/android.zip",
+		["win64"] = "builds/android/{0}/android.zip",
+	  }
+	}
   };
 }
 
-public enum Platform
+public enum TargetPlatform
 {
-    Unknown,
-    Ubuntu1804x64,
-    Ubuntu2004x64,
-    Ubuntu2204x64,
-    Ubuntu1804arm64,
-    Ubuntu2004arm64,
-    Ubuntu2204arm64,
-    Debian11x64,
-    Debian11arm64,
-    Debian12x64,
-    Debian12arm64,
-    Mac1013,
-    Mac1014,
-    Mac1015,
-    Mac11,
-    Mac11arm64,
-    Mac12,
-    Mac12arm64,
-    Mac13,
-    Mac13arm64,
-    Mac14,
-    Mac14arm64,
-    Win64
+	Unknown,
+	Ubuntu1804x64,
+	Ubuntu2004x64,
+	Ubuntu2204x64,
+	Ubuntu1804arm64,
+	Ubuntu2004arm64,
+	Ubuntu2204arm64,
+	Debian11x64,
+	Debian11arm64,
+	Debian12x64,
+	Debian12arm64,
+	Mac1013,
+	Mac1014,
+	Mac1015,
+	Mac11,
+	Mac11arm64,
+	Mac12,
+	Mac12arm64,
+	Mac13,
+	Mac13arm64,
+	Mac14,
+	Mac14arm64,
+	Win64,
+}
+
+public enum BrowserInfo
+{
+	Chromium,
+	ChromiumTipOfTree,
+	Firefox,
+	FirefoxBeta,
+	FirefoxAsan,
+	Webkit,
+	Ffmpeg,
+	Android
+}
+
+public static class Extensions
+{
+	public static string ToReadableString(this TargetPlatform platform)
+	{
+		switch (platform)
+		{
+			case TargetPlatform.Unknown:
+				return "<unknown>";
+			case TargetPlatform.Ubuntu1804x64:
+				return "ubuntu18.04-x64";
+			case TargetPlatform.Ubuntu2004x64:
+				return "ubuntu20.04-x64";
+			case TargetPlatform.Ubuntu2204x64:
+				return "ubuntu22.04-x64";
+			case TargetPlatform.Ubuntu1804arm64:
+				return "ubuntu18.04-arm64";
+			case TargetPlatform.Ubuntu2004arm64:
+				return "ubuntu20.04-arm64";
+			case TargetPlatform.Ubuntu2204arm64:
+				return "ubuntu22.04-arm64";
+			case TargetPlatform.Debian11x64:
+				return "debian11-x64";
+			case TargetPlatform.Debian11arm64:
+				return "debian11-arm64";
+			case TargetPlatform.Debian12x64:
+				return "debian12-x64";
+			case TargetPlatform.Debian12arm64:
+				return "debian12-arm64";
+			case TargetPlatform.Mac1013:
+				return "mac10.13";
+			case TargetPlatform.Mac1014:
+				return "mac10.14";
+			case TargetPlatform.Mac1015:
+				return "mac10.15";
+			case TargetPlatform.Mac11:
+				return "mac11";
+			case TargetPlatform.Mac11arm64:
+				return "mac11-arm64";
+			case TargetPlatform.Mac12:
+				return "mac12";
+			case TargetPlatform.Mac12arm64:
+				return "mac12-arm64";
+			case TargetPlatform.Mac13:
+				return "mac13";
+			case TargetPlatform.Mac13arm64:
+				return "mac13-arm64";
+			case TargetPlatform.Mac14:
+				return "mac14";
+			case TargetPlatform.Mac14arm64:
+				return "mac14-arm64";
+			case TargetPlatform.Win64:
+				return "win64";
+			default:
+				throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
+		}
+		
+	}
+
+	public static string ToReadableString(this BrowserInfo browserType)
+	{
+		switch (browserType)
+		{
+			case BrowserInfo.Chromium:
+				return "chromium";
+			case BrowserInfo.ChromiumTipOfTree:
+				return "chromium-tip-of-tree";
+			case BrowserInfo.Firefox:
+				return "firefox";
+			case BrowserInfo.FirefoxBeta:
+				return "firefox-beta";
+			case BrowserInfo.FirefoxAsan:
+				return "firefox-asan";
+			case BrowserInfo.Webkit:
+				return "webkit";
+			case BrowserInfo.Ffmpeg:
+				return "ffmpeg";
+			case BrowserInfo.Android:
+				return "android";
+			default:
+				throw new ArgumentOutOfRangeException(nameof(browserType), browserType, null);
+		}
+	}
 }

--- a/Playwright.BrowserDownloader/Playwright.BrowserDownloader.csproj
+++ b/Playwright.BrowserDownloader/Playwright.BrowserDownloader.csproj
@@ -9,9 +9,9 @@
   <!-- NuGet -->
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <AssemblyVersion>0.1.2</AssemblyVersion>
-    <AssemblyFileVersion>0.1.2</AssemblyFileVersion>
-    <Version>0.1.2</Version>
+    <AssemblyVersion>0.2.0</AssemblyVersion>
+    <AssemblyFileVersion>0.2.0</AssemblyFileVersion>
+    <Version>0.2.0</Version>
     <Title>nor0x.Playwright.BrowserDownloader</Title>
     <PackageId>nor0x.Playwright.BrowserDownloader</PackageId>
     <PackageReleaseNotes>https://github.com/nor0x/Playwright.BrowserDownloader/releases</PackageReleaseNotes>

--- a/Playwright.BrowserDownloader/browsers.json
+++ b/Playwright.BrowserDownloader/browsers.json
@@ -3,15 +3,15 @@
   "browsers": [
     {
       "name": "chromium",
-      "revision": "1112",
+      "revision": "1113",
       "installByDefault": true,
-      "browserVersion": "124.0.6367.29"
+      "browserVersion": "124.0.6367.49"
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1209",
+      "revision": "1212",
       "installByDefault": false,
-      "browserVersion": "125.0.6398.0"
+      "browserVersion": "125.0.6421.0"
     },
     {
       "name": "firefox",
@@ -33,7 +33,7 @@
     },
     {
       "name": "webkit",
-      "revision": "1995",
+      "revision": "2000",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",

--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,8 @@ a small and simple helper library to manually download browsers for playwright u
 [![](https://img.shields.io/nuget/dt/nor0x.Playwright.BrowserDownloader)](https://www.nuget.org/packages/nor0x.Playwright.BrowserDownloader)
 
 
+this library is under development - the API is subject to change.
+
 
 
 # Usage

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,8 +1,28 @@
-﻿using nor0x.Playwright.BrowserDownloader;
+﻿using Microsoft.Playwright;
+using nor0x.Playwright.BrowserDownloader;
 
 Console.WriteLine("Hello World!");
 var downloader = new BrowserDownloader();
-await downloader.DownloadBrowserAsync("chromium", "mac12", progressCallback:new Progress<double>(progressCallback));
+
+
+var os = Environment.OSVersion;
+var osName = os.Platform.ToString().ToLower();
+var platform = TargetPlatform.Ubuntu2204x64;
+if (osName.Contains("win"))
+{
+    platform = TargetPlatform.Win64;
+}
+else if (osName.Contains("mac"))
+{
+    platform = TargetPlatform.Mac14;
+}
+
+Console.WriteLine("Downloading browser for platform: " + platform);
+var playwright = await Playwright.CreateAsync();
+
+var path = await downloader.DownloadBrowserAsync(BrowserInfo.ChromiumTipOfTree, platform, executablePath: playwright.Chromium.ExecutablePath, progressCallback:new Progress<double>(progressCallback));
+
+Console.WriteLine("Downloaded browser to: " + path);
 
 void progressCallback(double obj)
 {

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.43.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Playwright.BrowserDownloader\Playwright.BrowserDownloader.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- enum values instead of string values for downloading
- proper executable path checks for installation
- adds browser platform to installation_complete file
- refactoring
- browsers.json bumped
- fixed download path on Linux