### PR TITLE
bump from 1.44.0

### DIFF
--- a/Playwright.BrowserDownloader/Constants.cs
+++ b/Playwright.BrowserDownloader/Constants.cs
@@ -157,34 +157,6 @@ public static class Constants
 		["win64"] = "builds/firefox-beta/{0}/firefox-beta-win64.zip",
 	  }
 	}, {
-	  "firefox-asan",
-	  new Dictionary < string,
-	  string > {
-		["<unknown>"] = null,
-		["ubuntu18.04-x64"] = null,
-		["ubuntu20.04-x64"] = null,
-		["ubuntu22.04-x64"] = "builds/firefox/{0}/firefox-asan-ubuntu-22.04.zip",
-		["ubuntu18.04-arm64"] = null,
-		["ubuntu20.04-arm64"] = null,
-		["ubuntu22.04-arm64"] = null,
-		["debian11-x64"] = null,
-		["debian11-arm64"] = null,
-		["debian12-x64"] = null,
-		["debian12-arm64"] = null,
-		["mac10.13"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac10.14"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac10.15"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac11"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac11-arm64"] = null,
-		["mac12"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac12-arm64"] = null,
-		["mac13"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac13-arm64"] = null,
-		["mac14"] = "builds/firefox/{0}/firefox-asan-mac-13.zip",
-		["mac14-arm64"] = null,
-		["win64"] = null,
-	  }
-	}, {
 	  "webkit",
 	  new Dictionary < string,
 	  string > {
@@ -305,7 +277,6 @@ public enum BrowserInfo
 	ChromiumTipOfTree,
 	Firefox,
 	FirefoxBeta,
-	FirefoxAsan,
 	Webkit,
 	Ffmpeg,
 	Android
@@ -366,7 +337,7 @@ public static class Extensions
 			default:
 				throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
 		}
-		
+
 	}
 
 	public static string ToReadableString(this BrowserInfo browserType)
@@ -381,8 +352,6 @@ public static class Extensions
 				return "firefox";
 			case BrowserInfo.FirefoxBeta:
 				return "firefox-beta";
-			case BrowserInfo.FirefoxAsan:
-				return "firefox-asan";
 			case BrowserInfo.Webkit:
 				return "webkit";
 			case BrowserInfo.Ffmpeg:

--- a/Playwright.BrowserDownloader/Playwright.BrowserDownloader.csproj
+++ b/Playwright.BrowserDownloader/Playwright.BrowserDownloader.csproj
@@ -9,9 +9,9 @@
   <!-- NuGet -->
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
-    <AssemblyFileVersion>0.2.0</AssemblyFileVersion>
-    <Version>0.2.0</Version>
+    <AssemblyVersion>0.2.1</AssemblyVersion>
+    <AssemblyFileVersion>0.2.1</AssemblyFileVersion>
+    <Version>0.2.1</Version>
     <Title>nor0x.Playwright.BrowserDownloader</Title>
     <PackageId>nor0x.Playwright.BrowserDownloader</PackageId>
     <PackageReleaseNotes>https://github.com/nor0x/Playwright.BrowserDownloader/releases</PackageReleaseNotes>

--- a/Playwright.BrowserDownloader/browsers.json
+++ b/Playwright.BrowserDownloader/browsers.json
@@ -3,43 +3,39 @@
   "browsers": [
     {
       "name": "chromium",
-      "revision": "1113",
+      "revision": "1119",
       "installByDefault": true,
-      "browserVersion": "124.0.6367.49"
+      "browserVersion": "126.0.6478.8"
     },
     {
       "name": "chromium-tip-of-tree",
-      "revision": "1212",
+      "revision": "1222",
       "installByDefault": false,
-      "browserVersion": "125.0.6421.0"
+      "browserVersion": "126.0.6478.8"
     },
     {
       "name": "firefox",
-      "revision": "1447",
+      "revision": "1449",
       "installByDefault": true,
-      "browserVersion": "124.0"
-    },
-    {
-      "name": "firefox-asan",
-      "revision": "1447",
-      "installByDefault": false,
-      "browserVersion": "124.0"
+      "browserVersion": "125.0.1"
     },
     {
       "name": "firefox-beta",
-      "revision": "1447",
+      "revision": "1449",
       "installByDefault": false,
-      "browserVersion": "125.0b3"
+      "browserVersion": "126.0b1"
     },
     {
       "name": "webkit",
-      "revision": "2000",
+      "revision": "2010",
       "installByDefault": true,
       "revisionOverrides": {
         "mac10.14": "1446",
         "mac10.15": "1616",
         "mac11": "1816",
-        "mac11-arm64": "1816"
+        "mac11-arm64": "1816",
+        "mac12": "2009",
+        "mac12-arm64": "2009"
       },
       "browserVersion": "17.4"
     },


### PR DESCRIPTION
- browser.json updated
- firefox-asan dropped (see: https://github.com/microsoft/playwright/pull/30626)
- version bump